### PR TITLE
:plus: Add cmake-arm-embedded/0.1.0 to demos/

### DIFF
--- a/demos/CMakeLists.txt
+++ b/demos/CMakeLists.txt
@@ -42,7 +42,6 @@ foreach(target IN LISTS TARGETS)
             -Wl,-Map=${current_project}.map,--cref -Wl,--gc-sections
             -Wl,--print-memory-usage)
         target_link_libraries(${current_project} PRIVATE libhal::lpc40xx)
-
-        arm_post_build(${current_project})
+        arm_cortex_post_build(${current_project})
     endforeach()
 endforeach()

--- a/demos/conanfile.txt
+++ b/demos/conanfile.txt
@@ -3,6 +3,7 @@ libhal-lpc40xx/0.3.4
 
 [tool_requires]
 gnu-arm-embedded-toolchain/11.3.0
+cmake-arm-embedded/0.1.0
 
 [generators]
 CMakeToolchain


### PR DESCRIPTION
The toolchain.cmake file was moved from libhal-armcortex to its own repo and package to allow toolchain and cmake files to change without affecting the version of the drivers.