### PR TITLE
:arrow_down: Bring demo version down to 0.3.5

### DIFF
--- a/demos/conanfile.txt
+++ b/demos/conanfile.txt
@@ -1,9 +1,9 @@
 [requires]
-libhal-lpc40xx/0.3.6
+libhal-lpc40xx/0.3.5
 
 [tool_requires]
 gnu-arm-embedded-toolchain/11.3.0
-cmake-arm-embedded/0.1.0
+cmake-arm-embedded/0.1.1
 
 [generators]
 CMakeToolchain


### PR DESCRIPTION
- 0.3.6 does not exist
- Bump version of cmake-arm-embedded to 0.1.1