### PR TITLE
:bug: Fix `can::configure()` changing nothing

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -11,7 +11,7 @@ required_conan_version = ">=1.50.0"
 
 class LibhalLPC40xxConan(ConanFile):
     name = "libhal-lpc40xx"
-    version = "0.3.5"
+    version = "0.3.6"
     license = "Apache-2.0"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://libhal.github.io/libhal-lpc40xx"

--- a/demos/conanfile.txt
+++ b/demos/conanfile.txt
@@ -1,5 +1,5 @@
 [requires]
-libhal-lpc40xx/0.3.5
+libhal-lpc40xx/0.3.6
 
 [tool_requires]
 gnu-arm-embedded-toolchain/11.3.0

--- a/include/libhal-lpc40xx/can.hpp
+++ b/include/libhal-lpc40xx/can.hpp
@@ -517,7 +517,7 @@ inline status can::setup(const can::port& p_port, settings p_settings)
 
 inline status can::driver_configure(const settings& p_settings)
 {
-  return configure_baud_rate(m_port, p_settings);
+  return setup(m_port, p_settings);
 }
 
 inline status can::driver_send(const message_t& p_message)


### PR DESCRIPTION
`can::configure()` should be calling `setup()` each time and not `configure_baud_rate()`. Once the CAN peripheral is enabled, then modifications to the clock rate settings is not possible. But setup() disables the peripheral first before setting up the clock rates.

- Bump version to 0.3.6