### PR TITLE
:rocket: Launch version 1.0.0

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -11,7 +11,7 @@ required_conan_version = ">=1.50.0"
 
 class LibhalLPC40xxConan(ConanFile):
     name = "libhal-lpc40xx"
-    version = "0.3.12"
+    version = "1.0.0"
     license = "Apache-2.0"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://libhal.github.io/libhal-lpc40xx"
@@ -39,9 +39,9 @@ class LibhalLPC40xxConan(ConanFile):
         }
 
     def requirements(self):
-        self.requires("libhal/[^0.3.5]")
-        self.requires("libhal-util/[^0.3.9]")
-        self.requires("libhal-armcortex/[^0.3.10]")
+        self.requires("libhal/[^1.0.0]")
+        self.requires("libhal-util/[^1.0.0]")
+        self.requires("libhal-armcortex/[^1.0.0]")
         self.requires("ring-span-lite/[^0.6.0]")
 
     def validate(self):

--- a/demos/CMakeLists.txt
+++ b/demos/CMakeLists.txt
@@ -1,21 +1,21 @@
 cmake_minimum_required(VERSION 3.20)
 
-# Set project name to demos
-project(demos VERSION 0.0.1 LANGUAGES CXX)
-
-# Import the libhal-lpc40xx library/package (and all of its dependencies)
-find_package(libhal-lpc40xx REQUIRED CONFIG)
-
 if(NOT DEFINED CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE "Debug" CACHE INTERNAL "Default to Debug Build")
 endif(NOT DEFINED CMAKE_BUILD_TYPE)
 
 set(CMAKE_TOOLCHAIN_FILE conan_toolchain.cmake)
 
+# Set project name to demos
+project(demos VERSION 0.0.1 LANGUAGES CXX)
+
+# Import the libhal-lpc40xx library/package (and all of its dependencies)
+find_package(libhal-lpc40xx REQUIRED CONFIG)
+
 # List of demo applications
 # To add a new demo to the list, simply add its filename without the .cpp
 # extension to this list.
-set(DEMOS adc blinker can empty gpio i2c interrupt_pin uart)
+set(DEMOS adc blinker can gpio i2c interrupt_pin uart)
 
 # List of targets in the LPC40 series MCU
 # TODO: Add targets for LPC17 series MCUs as these libraries are mostly

--- a/demos/applications/adc.cpp
+++ b/demos/applications/adc.cpp
@@ -22,10 +22,10 @@ hal::status application()
     using namespace std::chrono_literals;
 
     // Read ADC values from both ADC channel 2 & ADC 4
-    auto percent2 = adc2.read().value();
-    auto percent4 = adc4.read().value();
+    auto percent2 = adc2.read().value().sample;
+    auto percent4 = adc4.read().value().sample;
     // Get current uptime
-    auto uptime = counter.uptime().value();
+    auto uptime = counter.uptime().value().ticks;
     // Compute string from uptime count
     auto count = snprintf(buffer.data(),
                           buffer.size(),

--- a/demos/applications/can.cpp
+++ b/demos/applications/can.cpp
@@ -57,7 +57,7 @@
     (void)hal::write(uart0, std::span(buffer.data(), count));
   };
 
-  HAL_CHECK(can1.on_receive(receive_handler));
+  can1.on_receive(receive_handler);
 
   while (true) {
     using namespace std::chrono_literals;
@@ -71,7 +71,6 @@
 
     hal::print(uart0, "Sending payload...\n");
     HAL_CHECK(can2.send(my_message));
-
     HAL_CHECK(hal::delay(counter, 1s));
   }
 }

--- a/demos/applications/empty.cpp
+++ b/demos/applications/empty.cpp
@@ -1,7 +1,0 @@
-
-#include <libhal/error.hpp>
-
-hal::status application()
-{
-  return hal::success();
-}

--- a/demos/applications/gpio.cpp
+++ b/demos/applications/gpio.cpp
@@ -17,7 +17,7 @@ hal::status application()
   while (true) {
     // Checking level for the lpc40xx drivers NEVER generates an error so this
     // is fine.
-    if (button.level().value()) {
+    if (button.level().value().state) {
       using namespace std::chrono_literals;
       HAL_CHECK(led.level(false));
       HAL_CHECK(hal::delay(clock, 200ms));

--- a/demos/applications/interrupt_pin.cpp
+++ b/demos/applications/interrupt_pin.cpp
@@ -11,7 +11,7 @@ hal::status application()
 
   HAL_CHECK(button.configure({}));
   button.on_trigger([&led]([[maybe_unused]] bool p_level) {
-    bool current_voltage_level = led.level().value();
+    bool current_voltage_level = led.level().value().state;
     (void)led.level(!current_voltage_level);
   });
 

--- a/demos/conanfile.txt
+++ b/demos/conanfile.txt
@@ -1,5 +1,5 @@
 [requires]
-libhal-lpc40xx/0.3.11
+libhal-lpc40xx/1.0.0
 
 [tool_requires]
 gnu-arm-embedded-toolchain/11.3.0

--- a/include/libhal-lpc40xx/adc.hpp
+++ b/include/libhal-lpc40xx/adc.hpp
@@ -291,14 +291,14 @@ private:
   {
   }
 
-  result<float> driver_read() override
+  result<read_t> driver_read() override
   {
     constexpr auto max = bit_limits<12, size_t>::max();
     constexpr auto max_float = static_cast<float>(max);
     // Read sample from peripheral memory
     auto sample_integer = hal::bit::extract<data_register::result>(*m_sample);
     auto sample = static_cast<float>(sample_integer);
-    return sample / max_float;
+    return read_t{ .sample = sample / max_float };
   }
 
   volatile uint32_t* m_sample = nullptr;

--- a/include/libhal-lpc40xx/i2c.hpp
+++ b/include/libhal-lpc40xx/i2c.hpp
@@ -176,7 +176,7 @@ public:
   }
 
   status driver_configure(const settings& p_settings) override;
-  status driver_transaction(
+  result<transaction_t> driver_transaction(
     hal::byte p_address,
     std::span<const hal::byte> p_data_out,
     std::span<hal::byte> p_data_in,
@@ -228,7 +228,7 @@ inline status i2c::driver_configure(const settings& p_settings)
   const auto low_side_clocks = clock_divider - high_side_clocks;
 
   if (low_side_clocks < 1.0f || high_side_clocks < 1.0f) {
-    hal::new_error(std::errc::result_out_of_range);
+    return hal::new_error(std::errc::result_out_of_range);
   }
 
   // Power on peripheral
@@ -292,7 +292,7 @@ inline void i2c::disable()
   cortex_m::interrupt(static_cast<int>(m_bus.irq_number)).disable();
 }
 
-inline hal::status i2c::driver_transaction(
+inline result<i2c::transaction_t> i2c::driver_transaction(
   hal::byte p_address,
   std::span<const hal::byte> p_data_out,
   std::span<hal::byte> p_data_in,
@@ -318,7 +318,7 @@ inline hal::status i2c::driver_transaction(
     return hal::new_error(m_status);
   }
 
-  return hal::success();
+  return transaction_t{};
 }
 
 inline void i2c::interrupt()

--- a/include/libhal-lpc40xx/input_pin.hpp
+++ b/include/libhal-lpc40xx/input_pin.hpp
@@ -50,7 +50,7 @@ private:
   }
 
   status driver_configure(const settings& p_settings) override;
-  result<bool> driver_level() override;
+  result<level_t> driver_level() override;
 
   uint8_t m_port{};
   uint8_t m_pin{};
@@ -79,9 +79,11 @@ inline status input_pin::driver_configure(const settings& p_settings)
   return hal::success();
 }
 
-inline result<bool> input_pin::driver_level()
+inline result<hal::input_pin::level_t> input_pin::driver_level()
 {
-  return bit::extract(internal::pin_mask(m_pin),
-                      internal::gpio_reg(m_port)->pin);
+  auto pin_value =
+    bit::extract(internal::pin_mask(m_pin), internal::gpio_reg(m_port)->pin);
+
+  return level_t{ .state = static_cast<bool>(pin_value) };
 }
 }  // namespace hal::lpc40xx

--- a/include/libhal-lpc40xx/output_pin.hpp
+++ b/include/libhal-lpc40xx/output_pin.hpp
@@ -50,8 +50,8 @@ private:
   }
 
   status driver_configure(const settings& p_settings) override;
-  status driver_level(bool p_high) override;
-  result<bool> driver_level() override;
+  result<set_level_t> driver_level(bool p_high) override;
+  result<level_t> driver_level() override;
 
   std::uint8_t m_port{};
   std::uint8_t m_pin{};
@@ -72,7 +72,7 @@ inline status output_pin::driver_configure(const settings& p_settings)
   return hal::success();
 }
 
-inline status output_pin::driver_level(bool p_high)
+inline result<output_pin::set_level_t> output_pin::driver_level(bool p_high)
 {
   if (p_high) {
     bit::modify(internal::gpio_reg(m_port)->pin).set(internal::pin_mask(m_pin));
@@ -81,12 +81,14 @@ inline status output_pin::driver_level(bool p_high)
       .clear(internal::pin_mask(m_pin));
   }
 
-  return hal::success();
+  return set_level_t{};
 }
 
-inline result<bool> output_pin::driver_level()
+inline result<output_pin::level_t> output_pin::driver_level()
 {
-  return bit::extract(internal::pin_mask(m_pin),
-                      internal::gpio_reg(m_port)->pin);
+  auto pin_value =
+    bit::extract(internal::pin_mask(m_pin), internal::gpio_reg(m_port)->pin);
+
+  return level_t{ .state = static_cast<bool>(pin_value) };
 }
 }  // namespace hal::lpc40xx

--- a/include/libhal-lpc40xx/uart.hpp
+++ b/include/libhal-lpc40xx/uart.hpp
@@ -311,7 +311,7 @@ private:
   status driver_configure(const settings& p_settings) override;
   result<write_t> driver_write(std::span<const hal::byte> p_data) override;
   result<read_t> driver_read(std::span<hal::byte> p_data) override;
-  status driver_flush() override;
+  result<flush_t> driver_flush() override;
 
   void configure_baud_rate(internal::uart_baud_t p_calibration);
   void reset_uart_queue();
@@ -404,12 +404,12 @@ inline result<serial::read_t> uart::driver_read(std::span<hal::byte> p_data)
   };
 }
 
-inline status uart::driver_flush()
+inline result<serial::flush_t> uart::driver_flush()
 {
   while (!m_receive_buffer.empty()) {
     m_receive_buffer.pop_back();
   }
-  return success();
+  return flush_t{};
 }
 
 inline void uart::configure_baud_rate(internal::uart_baud_t p_calibration)

--- a/test_package/main.cpp
+++ b/test_package/main.cpp
@@ -4,9 +4,9 @@
 int main()
 {
   auto& input_pin = hal::lpc40xx::input_pin::get<2, 0>().value();
-  hal::result<bool> pin_level = input_pin.level();
+  hal::result<hal::input_pin::level_t> pin_level = input_pin.level();
   if (pin_level) {
-    printf("Pin Level = %d\n", pin_level.value());
+    printf("Pin Level = %d\n", pin_level.value().state);
   } else {
     printf("Reading pin level failed!\n");
   }

--- a/tests/conanfile.txt
+++ b/tests/conanfile.txt
@@ -1,6 +1,6 @@
 [requires]
 boost-ext-ut/1.1.9
-libhal-lpc40xx/0.3.11
+libhal-lpc40xx/1.0.0
 
 [generators]
 CMakeToolchain

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -7,6 +7,8 @@ set -e
 script_path="$(dirname "${BASH_SOURCE[0]}")"
 cd $script_path
 
+conan create ..
+
 # Create, if not present, the "build" directory and move into it
 mkdir -p build
 cd build


### PR DESCRIPTION
- :arrow_up: Upgrade to libhal/[^1.0.0]. Using `^` to ensure that libhal-util can work any other library with a compatible major number of libhal.
- :arrow_up: Upgrade to libhal-util/[^1.0.0]. Using `^` to ensure that libhal-util can work any other library with a compatible major number of libhal.
- :arrow_up: Upgrade to libhal-armcortex/[^1.0.0]. Using `^` to ensure that libhal-util can work any other library with a compatible major number of libhal.
- :recycle: Refactor code to use latest libhal code
- :adhesive_bandage: Fix ordering of toolchain code in demos/CMakeLists.txt
- :fire: Remove demo/empty.cpp, because it does nothing and adds no value.